### PR TITLE
SUGGESTION: text improvement and temp hide of newsletter

### DIFF
--- a/docs/contact.html
+++ b/docs/contact.html
@@ -26,7 +26,7 @@
        </div>
        <div class="row">
          <div class="col-md-3"></div>
-         <div class="col-md-6 small-dayof">
+         <div class="col-md-6 small-dayof-title">
             <div>
               <span>June 23rd, 2023 - De Doelen, Rotterdam</span>
             </div>
@@ -108,11 +108,11 @@
          </div>
          <div class="col-sm-5 twocol">
 
-          <h2 id="newsletter">Newsletter</h2>
+<!--          <h2 id="newsletter">Newsletter</h2>-->
 
-          <p><i class="fa fa-envelope"></i>
-             <a href="https://joyofcoding.us6.list-manage.com/subscribe?u=3c1a490ebd&id=a52a450c87">Sign up for our low-traffic newsletter</a> - roughly one e-mail per month in the half-year before the conference,
-             or read the previous newsletters in our <a href="https://us6.campaign-archive.com/home/?u=3c1a490ebd&id=a52a450c87">archive</a>.</p>
+<!--          <p><i class="fa fa-envelope"></i>-->
+<!--             <a href="https://joyofcoding.us6.list-manage.com/subscribe?u=3c1a490ebd&id=a52a450c87">Sign up for our low-traffic newsletter</a> - roughly one e-mail per month in the half-year before the conference,-->
+<!--             or read the previous newsletters in our <a href="https://us6.campaign-archive.com/home/?u=3c1a490ebd&id=a52a450c87">archive</a>.</p>-->
           
           <h2 id="email">E-mail</h2>
              <p>

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -102,6 +102,20 @@ body {
 	text-transform: uppercase;
 }
 
+.small-dayof-title {
+	background-color: #824d67;
+	color: white;
+	font-family: 'Teko', sans-serif;
+	font-weight: 400;
+	font-size: 25pt;
+	text-align: center;
+	padding-top: 5px;
+	padding-bottom: 5px;
+	margin-bottom: 20px;
+	margin-top: 20px;
+	text-transform: uppercase;
+}
+
 .navigation {
 	font-family: 'Teko', sans-serif;
 	font-weight: 300;

--- a/docs/sponsoring.html
+++ b/docs/sponsoring.html
@@ -26,7 +26,7 @@
        </div>
        <div class="row">
          <div class="col-md-3"></div>
-         <div class="col-md-6 small-dayof">
+         <div class="col-md-6 small-dayof-title">
             <div>
               <span>June 23rd, 2023 - De Doelen, Rotterdam</span>
             </div>
@@ -79,7 +79,7 @@
 
       <h2 id="conference">The conference</h2>
 
-      <p>Joy of Coding 2023 is the 9th edition in a series of conferences dedicated to the art, science, hobby, but most of all <em>the joy</em> of software development. This year’s edition will be held on Friday the 23rd of June in the De Doelen, Rotterdam: a convention center at the heart of the city, easily accessible by public transport and by car.</p>
+      <p>Joy of Coding 2023 is the 9th edition in a series of conferences dedicated to the art, science, hobby, but most of all <em>the joy</em> of software development. This year’s edition will be held on Friday the 23rd of June in <em>De Doelen, Rotterdam</em>: a convention center at the heart of the city, easily accessible by public transport and by car.</p>
 
       <h2 id="mission">Our mission</h2>
 


### PR DESCRIPTION
- `dayof` styling of header title for `Sponsoring` and `Contact` page
- Improve text on `Sponsoring` page
- Temporarily hide `Newsletter` information on `Contact` page because of outdated links