### PR TITLE
Updated Makefile to handle installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ serve: web
 web: jekyll_build
 	cp -a jekyll/_site/* docs
 
-jekyll_build: 
-	jekyll build --source jekyll --destination jekyll/_site
+jekyll_build: jekyll/vendor node_modules
+	cd jekyll; bundle exec jekyll build --source . --destination _site
 
+jekyll/vendor:
+	cd jekyll; bundle config set --local path vendor
+	cd jekyll; bundle install
+
+node_modules:
+	npm install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # Joy of Coding public website
 
+## Jekyll build
+
+The site is now built using Jekyll. It still uses a fair amount of plain html instead of trying to do
+everything in Markdown. The rationale is to have full control, while still leveraging Jekyll to make 
+recurring things like headers, footers and menu much easier to deal with.
+
+We don't let Github build the Jekyll site, meaning we run Jekyll locally using `make`, and commit
+the resulting html in the `docs` folder. 
+
+### Prerequisites
+These instructions assume a Debian based sytem
+
+Make sure the following packages are installed:
+ 
+ `apt install ruby-bundler ruby-dev build-essential npm`
+ 
+Then just run `make`, which should install everything needed and pop up a browser window.
+
+## Sites for previous years
+
 [http://joyofcoding.org](http://joyofcoding.org) has had a new website, each year 2013-2017.
 Each year’s website is now a static website in a sub-directory, including those generated with a site-builder, such as 2017 which was generated using Hugo (whose configuration was removed by an earlier commit).
 


### PR DESCRIPTION
Jekyll is now run through bundler, and the Makefile takes care of installation. It also runs npm install where needed.